### PR TITLE
run build:lib before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "mocha --recursive --compilers js:babel-core/register",
     "test:watch": "npm test -- --watch",
     "build:lib": "babel src --out-dir lib",
+    "prepublish": "npm run build:lib",
     "build:publish": "npm publish"
   },
   "main": "lib/index.js",


### PR DESCRIPTION
This also makes it possible to `npm i` with local directory, which invokes the build.