### PR TITLE
Cleanup documentation syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ const initialState = Immutable.fromJS({ isAuth: false })
  **/
 export default createReducer(initialState, {
   [LOGIN]: (state, action) => state.merge({
-    'isAuth': true, token: action.payload.token
+    isAuth: true,
+    token: action.payload.token
   }),
 
   [LOGOUT]: (domain) => domain.merge({
-    'isAuth': false,
-    'current_identity': {},
+    isAuth: false,
+    current_identity: {},
     token: undefined
   })
 })

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import * as reducers from './reducers';
 const reducer = combineReducers(reducers);
 const state = Immutable.fromJS({});
 
-const state = reducer(state);
+const store = reducer(state);
 export default createStore(reducer, state);
 ```
 
@@ -46,13 +46,15 @@ const initialState = Immutable.fromJS({ isAuth: false })
  * Reducer domain that handles authentication & authorization.
  **/
 export default createReducer(initialState, {
-  [LOGIN] (state, action) {
-    return state.merge({ 'isAuth': true, token: action.payload.token })
-  },
+  [LOGIN]: (state, action) => state.merge({
+    'isAuth': true, token: action.payload.token
+  }),
 
-  [LOGOUT] (domain) {
-    return domain.merge({ 'isAuth': false, 'current_identity': {}, token: undefined })
-  }
+  [LOGOUT]: (domain) => domain.merge({
+    'isAuth': false,
+    'current_identity': {},
+    token: undefined
+  })
 })
 ```
 
@@ -60,9 +62,7 @@ If you want to specify the Immutable type to be used for implicit conversion, pa
 
 ```js
 export default createReducer([], {
-  [ADD_STUFF] (state, {stuff}) {
-    return state.add(stuff);
-  }
+  [ADD_STUFF]: (state, { stuff }) => state.add(stuff)
 }, true, ::Immutable.OrderedSet);
 
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const reducer = combineReducers(reducers);
 const state = Immutable.fromJS({});
 
 const store = reducer(state);
-export default createStore(reducer, state);
+export default createStore(reducer, store);
 ```
 
 ## Immutable Handler Map reducer creator


### PR DESCRIPTION
- `state` was assigned twice, even though it's a `const`, which I think will throw an error at compile time when using Babel. Renamed second assignment to `store`.
- I cleaned up your reducers to use arrow syntax. This way you don't need to `return` (because implicit).
- Remove unnecessary quotes around keys