### PR TITLE
Map reducers to undefined for defaultState

### DIFF
--- a/src/utils/combineReducers.js
+++ b/src/utils/combineReducers.js
@@ -96,9 +96,7 @@ export default function combineReducers(reducers) {
     }
   });
 
-  var defaultState = finalReducers.map((r) => {
-    return r();
-  });
+  var defaultState = finalReducers.map(r => undefined);
   var stateShapeVerified;
 
   return function combination(state = defaultState, action) {


### PR DESCRIPTION
When calling `combineReducers`, we are iterating over the children an extra time to populate the `defaultState`. This leads to an initial reducer call where `action` is `undefined` – an annoying case to handle when expecting `action.type` to be defined everywhere!

This change maps the values in `defaultState` to `undefined` instead, bringing the functionality inline with [Redux's own behavior in `combineReducers`](https://github.com/rackt/redux/blob/master/src%2Futils%2FcombineReducers.js#L100)