### PR TITLE
combineReducer returns initial state if no mods by subReducers

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "immutable": "^3.7.5"
   },
   "devDependencies": {
+    "babel": "^5.8.23",
     "babel-core": "^5.6.18",
     "babel-loader": "^5.1.4",
     "eslint-config-airbnb": "0.0.8",

--- a/src/utils/combineReducers.js
+++ b/src/utils/combineReducers.js
@@ -100,8 +100,11 @@ export default function combineReducers(reducers) {
   var stateShapeVerified;
 
   return function combination(state = defaultState, action) {
+    var dirty = false;
     var finalState = finalReducers.map((reducer, key) => {
-      var newState = reducer(state.get(key), action);
+      var oldState = state.get(key);
+      var newState = reducer(oldState, action);
+      dirty = dirty || (oldState !== newState)
       if (typeof newState === 'undefined') {
         throw new Error(getErrorMessage(key, action));
       }
@@ -124,6 +127,6 @@ export default function combineReducers(reducers) {
       }
     }
 
-    return finalState;
+    return (dirty) ? finalState : state;
   };
 }

--- a/test/utils/combineReducers.js
+++ b/test/utils/combineReducers.js
@@ -6,14 +6,13 @@ const indexedOf = Immutable.Seq.Indexed.of;
 describe('Utils', () => {
   const initialState = Map();
   describe('combineReducers', () => {
+    const reducer = combineReducers({
+      counter: (state = 0, action = {}) =>
+        action.type === 'increment' ? state + 1 : state,
+      stack: (state = List(), action = {}) =>
+        action.type === 'push' ? state.push(action.value) : state
+    });
     it('should return a composite reducer that maps the state keys to given reducers', () => {
-      const reducer = combineReducers({
-        counter: (state = 0, action = {}) =>
-          action.type === 'increment' ? state + 1 : state,
-        stack: (state = List(), action = {}) =>
-          action.type === 'push' ? state.push(action.value) : state
-      });
-
       const s1 = reducer(initialState, { type: 'increment' });
       expect(Immutable.Map.isMap(s1)).toBe(true);
       expect(s1.get('counter')).toBe(1);
@@ -35,5 +34,10 @@ describe('Utils', () => {
       expect(reducer(initialState, { type: 'push' }).keySeq().equals(indexedOf('stack'))).toBe(true);
     });
 
+    it('returns the initial state when nothing changes', () => {
+      const s1 = reducer(initialState, { type: 'increment'});
+      const s2 = reducer(s1);
+      expect(s1).toBe(s2);
+    })
   });
 });


### PR DESCRIPTION
this allows you to now perform simple `===` test to see if the
combineReducer actually modified state.

Also added babel as a dev-dependency so do not need a global
babel install to build