### PR TITLE
Fix typo in description of #createReducer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ export default createStore(reducer, store);
 
 ## Immutable Handler Map reducer creator
 
-Using `createReducer` is an optional function that creates a reducer from a collection of handlers, except
+Using `createReducer` is an optional function that creates a reducer from a collection of handlers. In addition to
 getting rid of the _switch_ statement, it also provides the following benefits:
 
 1. If the given `initialState` type is mutated, it will get converted to an immutable type.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ export default createStore(reducer, store);
 ## Immutable Handler Map reducer creator
 
 Using `createReducer` is an optional function that creates a reducer from a collection of handlers, except
-getting ride of the _switch_ statement, it also provides the following benefits:
+getting rid of the _switch_ statement, it also provides the following benefits:
 
 1. If the given `initialState` type is mutated, it will get converted to an immutable type.
 1. An error is produced in case a reducer handler returns a mutated state (not recommended but this behavior can be disabled)


### PR DESCRIPTION
Changed "getting RIDE of" to "getting RID of."