### PR TITLE
Support unexpected keys and reduce the number of discarded duplicates

### DIFF
--- a/src/utils/combineReducers.js
+++ b/src/utils/combineReducers.js
@@ -110,9 +110,7 @@ export default function combineReducers(reducers) {
         throw new Error(getErrorMessage(key, action));
       }
 
-      if( oldState != newState ) {
-        finalState = finalState.set( key, newState );
-      }
+      finalState = finalState.set( key, newState );
     });
 
     if ((

--- a/src/utils/combineReducers.js
+++ b/src/utils/combineReducers.js
@@ -100,15 +100,19 @@ export default function combineReducers(reducers) {
   var stateShapeVerified;
 
   return function combination(state = defaultState, action) {
-    var dirty = false;
-    var finalState = finalReducers.map((reducer, key) => {
-      var oldState = state.get(key);
-      var newState = reducer(oldState, action);
-      dirty = dirty || (oldState !== newState)
+
+    let finalState = state;
+    finalReducers.forEach( ( reducer, key ) => {
+      const oldState = state.get( key );
+      const newState = reducer( oldState, action );
+
       if (typeof newState === 'undefined') {
         throw new Error(getErrorMessage(key, action));
       }
-      return newState;
+
+      if( oldState != newState ) {
+        finalState = finalState.set( key, newState );
+      }
     });
 
     if ((
@@ -127,6 +131,6 @@ export default function combineReducers(reducers) {
       }
     }
 
-    return (dirty) ? finalState : state;
+    return finalState;
   };
 }

--- a/test/utils/combineReducers.js
+++ b/test/utils/combineReducers.js
@@ -35,7 +35,7 @@ describe('Utils', () => {
     });
 
     it('returns the initial state when nothing changes', () => {
-      const s1 = reducer(initialState, { type: 'increment'});
+      const s1 = reducer(initialState, { type: 'increment' });
       const s2 = reducer(s1);
       expect(s1).toBe(s2);
     })

--- a/test/utils/combineReducers.js
+++ b/test/utils/combineReducers.js
@@ -39,5 +39,12 @@ describe('Utils', () => {
       const s2 = reducer(s1);
       expect(s1).toBe(s2);
     })
+
+    it('includes alll keys from original state', () => {
+      const unexpectedKeys = Map({ unexpected: true });
+      const reduced = reducer(unexpectedKeys, { type: 'INIT' });
+
+      expect( reduced.get('unexpected') ).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
Thanks for putting this library together. Makes ImmutableJS that much more usable for redux. I found a little bug in the current implementation that I fixed. Hopefully you'll find it useful as well.

This change fixes a couple little things.

1. It reduces the number of temporary maps that are discarded if there are no changes. While small, it means that for each action an Immutable.Map is created then immediately discarded for changes in larger object graphs. 

2. It also fixes a bug where key sin the original state are lost if there is no reducer mapped to that key. This also more closely matches the behavior of the combineReducers method from redux proper.

   ```javascript
   const state = Immutable.Map({ unexpected: true })
   const oldMethod = reduce( state, { type: 'ANYTHING' })

   oldMethod.get('unexpected') === false  // :/ not what we want

   const newMethod = reduce( state, { type: 'ANYTHING' })

   oldMethod.get('unexpected') === true  // Yay!
   ```